### PR TITLE
gui의 클릭 이벤트 트리거 전 버킷 클릭 이벤트 취소

### DIFF
--- a/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/gui/InventoryGui.kt
+++ b/InventoryGUI-api/src/main/kotlin/net/projecttl/inventory/gui/InventoryGui.kt
@@ -65,6 +65,7 @@ class InventoryGuiBuilder(private val player: Player, private val slotType: Inve
                 if (event.inventory == inv) {
                     for (slot in slots.entries) {
                         if (slot.key == event.rawSlot){
+                            event.isCancelled = true
                             slot.value.click(event)
                         }
                     }


### PR DESCRIPTION
현재까지 slot의 click 이벤트 부분에서 exception이 발생하면 클릭이벤트가 cancel이 되지 않아서 아이템을 꺼낼 수 있는 버그가 있었습니다. 이 버그를 수정했습니다.