### PR TITLE
fix: can't use on java 17

### DIFF
--- a/InventoryGUI-api/build.gradle.kts
+++ b/InventoryGUI-api/build.gradle.kts
@@ -7,8 +7,12 @@ plugins {
 }
 
 tasks {
+    withType<JavaCompile> {
+        options.release.set(17)
+    }
+
     withType<KotlinCompile> {
-        compilerOptions.jvmTarget.set(JvmTarget.JVM_21)
+        compilerOptions.jvmTarget.set(JvmTarget.JVM_17)
     }
 
     withType<Javadoc> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,7 +41,7 @@ subprojects {
 
     dependencies {
         implementation(kotlin("stdlib"))
-        compileOnly("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
+        compileOnly("io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT")
         if (this@subprojects.name != "InventoryGUI-api") {
             dependencies {
                 implementation(project(":InventoryGUI-api"))


### PR DESCRIPTION
> ```
> java.lang.UnsupportedClassVersionError: net/projecttl/inventory/util/InventoryType has been compiled by a more recent version of the Java Runtime (class file version 65.0), this version of the Java Runtime only recognizes class file versions up to 61.0
> 	at java.lang.ClassLoader.defineClass1(Native Method) ~[?:?]
> 	at java.lang.ClassLoader.defineClass(ClassLoader.java:1017) ~[?:?]
> 	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:150) ~[?:?]
> 	at java.net.URLClassLoader.defineClass(URLClassLoader.java:524) ~[?:?]
> 	at java.net.URLClassLoader$1.run(URLClassLoader.java:427) ~[?:?]
> 	at java.net.URLClassLoader$1.run(URLClassLoader.java:421) ~[?:?]
> 	at java.security.AccessController.doPrivileged(AccessController.java:712) ~[?:?]
> 	at java.net.URLClassLoader.findClass(URLClassLoader.java:420) ~[?:?]
> ```
> 
> 1.20.4 이하 여러 서버들은 java 17로 구동되는 경우가 많습니다. 호환성을 위해 자바 17에 맞게 빌드하는것도 한번 검토하시면 좋을 것 같습니다.

downgraded to 1.20.4 and switched to java 17

cant use on java 17 #32 